### PR TITLE
Add support for typing.Type[...]

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -42,7 +42,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     try:
         data_class_hints = get_type_hints(data_class, globalns=config.forward_references)
     except NameError as error:
-        raise ForwardReferenceError(str(error))
+        raise ForwardReferenceError(str(error)) from error
     data_class_fields = get_fields(data_class)
     if config.strict:
         extra_fields = set(data.keys()) - {f.name for f in data_class_fields}
@@ -66,10 +66,10 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
         except KeyError:
             try:
                 value = get_default_value_for_field(field)
-            except DefaultValueNotFoundError:
+            except DefaultValueNotFoundError as err:
                 if not field.init:
                     continue
-                raise MissingValueError(field.name)
+                raise MissingValueError(field.name) from err
         if field.init:
             init_values[field.name] = value
         else:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -127,6 +127,12 @@ def is_instance(value: Any, type_: Type) -> bool:
         if hasattr(type_, "type"):
             return is_instance(value, type_.type)
         return True
+    elif is_generic(type_) and type_.__origin__ is type:
+        inner_type = extract_generic(type_)[0]
+        try:
+            return issubclass(value, inner_type)
+        except TypeError:
+            return False
     else:
         try:
             # As described in PEP 484 - section: "The numeric tower"

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -127,7 +127,7 @@ def is_instance(value: Any, type_: Type) -> bool:
         if hasattr(type_, "type"):
             return is_instance(value, type_.type)
         return True
-    elif is_generic(type_) and type_.__origin__ is type:
+    elif is_generic(type_) and extract_origin_collection(type_) is type:
         inner_type = extract_generic(type_)[0]
         try:
             return issubclass(value, inner_type)

--- a/tests/core/test_type.py
+++ b/tests/core/test_type.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from typing import List, Type
+
+import pytest
+
+from dacite import from_dict, Config, WrongTypeError
+
+
+def test_from_dict_with_type_parameter():
+    @dataclass
+    class X:
+        l: Type[int]
+
+    result = from_dict(X, {"l": bool})  # bool is a subclass of int in Python
+
+    assert result == X(l=bool)
+
+
+def test_from_dict_with_list_of_type_parameters():
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    @dataclass
+    class Y:
+        class_list: List[Type[A]]
+
+    result = from_dict(Y, {"class_list": [A, B]})
+
+    assert result == Y(class_list=[A, B])
+
+
+def test_from_dict_with_type_parameter_and_type_hooks():
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    @dataclass
+    class Z:
+        class_: Type[A]
+
+    def from_string(s: str) -> Type[A]:
+        assert s in ("A", "B")
+        return A if s == "A" else B
+
+    result = from_dict(Z, {"class_": "B"}, config=Config(type_hooks={Type[A]: from_string}))
+
+    assert result == Z(class_=B)
+
+
+def test_from_dict_with_value_instead_of_type():
+    @dataclass
+    class X:
+        l: Type[int]
+
+    with pytest.raises(WrongTypeError) as exception_info:
+        from_dict(X, {"l": 1})
+
+    assert exception_info.value.field_path == "l"
+    assert exception_info.value.field_type == Type[int]
+
+
+def test_from_dict_with_wrong_type_for_type_parameter():
+    @dataclass
+    class X:
+        l: Type[int]
+
+    with pytest.raises(WrongTypeError) as exception_info:
+        from_dict(X, {"l": float})
+
+    assert exception_info.value.field_path == "l"
+    assert exception_info.value.field_type == Type[int]


### PR DESCRIPTION
This allows code like this:

```python
from typing import Type

class A:
    pass

class B(A):
    pass

@dataclass
class Config:
    class_: Type[A]

config = from_dict(Config, {"class_": B})
```